### PR TITLE
cached_network_image was not required in plugin

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,8 +10,6 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  cached_network_image: ^0.8.0
-
 flutter:
   plugin:
     androidPackage: com.shatsy.pinchzoomimage


### PR DESCRIPTION
cached_network_image was cause conflicts with the version on my main project
I think it was only required in example, 